### PR TITLE
Refactor CLI - extract most functions to separate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+Engineering:
+
+1. Refactor the code for easier maintenance
+2. Add unit tests for the CLI and individual functions
+
 ## v1.0.1 (2020-11-10)
 
 Bugfix release

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ some existing files are allowed to have TS errors.
 
 ## Features
 
-- ignored specific TS errors from specific files
+- ignores specific TS errors from specific files
 - detects files that no longer have to be loosely type-checked
 - auto-updates the loosely type-checked list of files when a file no longer has error
 

--- a/src/cli/cli-dependencies.ts
+++ b/src/cli/cli-dependencies.ts
@@ -1,9 +1,10 @@
 import { CliOptions } from './cli-options';
-import { saveJSONFile } from './io';
+import { readJSONArray, saveJSONFile } from './io';
 
 export interface CliDependencies {
   log: typeof console.log;
   saveJSONFile: typeof saveJSONFile;
+  readJSONArray: typeof readJSONArray;
   cliOptions: CliOptions;
 }
 
@@ -13,4 +14,5 @@ export const getCliDependencies = (
   cliOptions,
   log: console.log.bind(console),
   saveJSONFile,
+  readJSONArray,
 });

--- a/src/cli/cli-dependencies.ts
+++ b/src/cli/cli-dependencies.ts
@@ -1,0 +1,16 @@
+import { CliOptions } from './cli-options';
+import { saveJSONFile } from './io';
+
+export interface CliDependencies {
+  log: typeof console.log;
+  saveJSONFile: typeof saveJSONFile;
+  cliOptions: CliOptions;
+}
+
+export const getCliDependencies = (
+  cliOptions: CliOptions,
+): CliDependencies => ({
+  cliOptions,
+  log: console.log.bind(console),
+  saveJSONFile,
+});

--- a/src/cli/cli-options-config.ts
+++ b/src/cli/cli-options-config.ts
@@ -1,0 +1,29 @@
+export const cliOptionsConfig = {
+  'ignored-error-codes': {
+    type: 'string',
+    description:
+      'Path to a JSON file with an array of TSC error codes that should be ignored',
+    default: 'ignored-error-codes.json',
+    normalize: true,
+  },
+  'loosely-type-checked-files': {
+    type: 'string',
+    description:
+      'Path to a JSON file with an array of file paths that should be loosely checked.' +
+      '\nSpecified errors will be ignored in those files.',
+    default: 'loosely-type-checked-files.json',
+    normalize: true,
+  },
+  init: {
+    alias: ['i'],
+    type: 'boolean',
+    description: 'Initialize the JSON files with existing TSC errors',
+    default: false,
+  },
+  'auto-update': {
+    type: 'boolean',
+    description:
+      'When specified, the files that no longer have errors will be removed from the list of loosely type-checked files',
+    default: false,
+  },
+} as const;

--- a/src/cli/cli-options.ts
+++ b/src/cli/cli-options.ts
@@ -1,0 +1,6 @@
+export interface CliOptions {
+  'ignored-error-codes': string;
+  'loosely-type-checked-files': string;
+  init: boolean;
+  'auto-update': boolean;
+}

--- a/src/cli/config/get-config-files-from-errors.test.ts
+++ b/src/cli/config/get-config-files-from-errors.test.ts
@@ -1,0 +1,77 @@
+import { getConfigFilesFromErrors } from './get-config-files-from-errors';
+
+describe('getConfigFilesFromErrors', () => {
+  it('should return empty config files when there are no errors', () => {
+    const result = getConfigFilesFromErrors([]);
+
+    expect(result.ignoredErrorCodes).toHaveLength(0);
+    expect(result.looselyTypeCheckedFiles).toHaveLength(0);
+  });
+
+  it('should return a list of unique error codes and unique file paths', () => {
+    const result = getConfigFilesFromErrors([
+      {
+        filePath: 'a',
+        tscErrorCode: 'TS1234',
+        rawErrorLines: [],
+      },
+      {
+        filePath: 'a',
+        tscErrorCode: 'TS1235',
+        rawErrorLines: [],
+      },
+      {
+        filePath: 'b',
+        tscErrorCode: 'TS1234',
+        rawErrorLines: [],
+      },
+      {
+        filePath: 'c',
+        tscErrorCode: 'TS1236',
+        rawErrorLines: [],
+      },
+    ]);
+
+    expect(result.ignoredErrorCodes).toHaveLength(3);
+    expect(result.ignoredErrorCodes).toContain('TS1234');
+    expect(result.ignoredErrorCodes).toContain('TS1235');
+    expect(result.ignoredErrorCodes).toContain('TS1236');
+    expect(result.looselyTypeCheckedFiles).toHaveLength(3);
+    expect(result.looselyTypeCheckedFiles).toContain('a');
+    expect(result.looselyTypeCheckedFiles).toContain('b');
+    expect(result.looselyTypeCheckedFiles).toContain('c');
+  });
+
+  it('should sort the returned lists', () => {
+    const result = getConfigFilesFromErrors([
+      {
+        filePath: 'x',
+        tscErrorCode: 'TS1238',
+        rawErrorLines: [],
+      },
+      {
+        filePath: 'c',
+        tscErrorCode: 'TS1235',
+        rawErrorLines: [],
+      },
+      {
+        filePath: 'z',
+        tscErrorCode: 'TS1240',
+        rawErrorLines: [],
+      },
+      {
+        filePath: 'a',
+        tscErrorCode: 'TS1220',
+        rawErrorLines: [],
+      },
+    ]);
+
+    expect(result.ignoredErrorCodes).toEqual([
+      'TS1220',
+      'TS1235',
+      'TS1238',
+      'TS1240',
+    ]);
+    expect(result.looselyTypeCheckedFiles).toEqual(['a', 'c', 'x', 'z']);
+  });
+});

--- a/src/cli/config/get-config-files-from-errors.ts
+++ b/src/cli/config/get-config-files-from-errors.ts
@@ -1,0 +1,14 @@
+import { TscError } from '../../tsc-errors';
+
+export const getConfigFilesFromErrors = (tscErrors: TscError[]) => {
+  return {
+    looselyTypeCheckedFiles: getUniqueSortedArray(
+      tscErrors.map((error) => error.filePath),
+    ),
+    ignoredErrorCodes: getUniqueSortedArray(
+      tscErrors.map((error) => error.tscErrorCode),
+    ),
+  };
+};
+
+const getUniqueSortedArray = <T>(arr: T[]) => Array.from(new Set(arr)).sort();

--- a/src/cli/config/index.ts
+++ b/src/cli/config/index.ts
@@ -1,2 +1,3 @@
 export * from './initialize-config-files';
 export * from './update-loosely-type-checked-file-paths';
+export * from './read-config';

--- a/src/cli/config/index.ts
+++ b/src/cli/config/index.ts
@@ -1,0 +1,1 @@
+export * from './initialize-config-files';

--- a/src/cli/config/index.ts
+++ b/src/cli/config/index.ts
@@ -1,1 +1,2 @@
 export * from './initialize-config-files';
+export * from './update-loosely-type-checked-file-paths';

--- a/src/cli/config/initialize-config-files.test.ts
+++ b/src/cli/config/initialize-config-files.test.ts
@@ -1,0 +1,65 @@
+import { TscError } from '../../tsc-errors';
+import { getDefaultCliOptions } from '../get-default-cli-options';
+import { initializeConfigurationFiles } from './initialize-config-files';
+
+describe('initializeConfigurationFiles', () => {
+  const cliDependencies: Parameters<typeof initializeConfigurationFiles>[0] = {
+    cliOptions: getDefaultCliOptions(),
+    log: jest.fn(),
+    saveJSONFile: jest.fn(),
+  };
+
+  const tscErrors: TscError[] = [
+    {
+      filePath: 'a',
+      rawErrorLines: [],
+      tscErrorCode: 'TS1234',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should save files', () => {
+    initializeConfigurationFiles(cliDependencies, tscErrors);
+
+    expect(cliDependencies.saveJSONFile).toHaveBeenCalledTimes(2);
+    expect(cliDependencies.saveJSONFile).toHaveBeenCalledWith(
+      cliDependencies.cliOptions['ignored-error-codes'],
+      ['TS1234'],
+    );
+    expect(cliDependencies.saveJSONFile).toHaveBeenCalledWith(
+      cliDependencies.cliOptions['loosely-type-checked-files'],
+      ['a'],
+    );
+  });
+
+  it('should report errors when saving loosely type-checked files failed', () => {
+    (cliDependencies.saveJSONFile as jest.Mock).mockImplementation((path) =>
+      path === cliDependencies.cliOptions['loosely-type-checked-files']
+        ? new Error('Saving failed')
+        : undefined,
+    );
+
+    initializeConfigurationFiles(cliDependencies, tscErrors);
+
+    expect(cliDependencies.log).toHaveBeenCalledWith(
+      expect.stringContaining('Saving failed'),
+    );
+  });
+
+  it('should report errors when saving ignored error codes failed', () => {
+    (cliDependencies.saveJSONFile as jest.Mock).mockImplementation((path) =>
+      path === cliDependencies.cliOptions['ignored-error-codes']
+        ? new Error('Saving failed')
+        : undefined,
+    );
+
+    initializeConfigurationFiles(cliDependencies, tscErrors);
+
+    expect(cliDependencies.log).toHaveBeenCalledWith(
+      expect.stringContaining('Saving failed'),
+    );
+  });
+});

--- a/src/cli/config/initialize-config-files.ts
+++ b/src/cli/config/initialize-config-files.ts
@@ -1,0 +1,42 @@
+import { red } from 'chalk';
+import { TscError } from '../../tsc-errors';
+import { CliDependencies } from '../cli-dependencies';
+import { getConfigFilesFromErrors } from './get-config-files-from-errors';
+
+export function initializeConfigurationFiles(
+  {
+    cliOptions,
+    log,
+    saveJSONFile,
+  }: Pick<CliDependencies, 'cliOptions' | 'log' | 'saveJSONFile'>,
+  tscErrors: TscError[],
+) {
+  log('Initializing configuration files...');
+
+  const {
+    looselyTypeCheckedFiles,
+    ignoredErrorCodes,
+  } = getConfigFilesFromErrors(tscErrors);
+
+  const saveLooselyTypeCheckedFilesError = saveJSONFile(
+    cliOptions['loosely-type-checked-files'],
+    looselyTypeCheckedFiles,
+  );
+  if (saveLooselyTypeCheckedFilesError) {
+    log(red(`Error when saving ${cliOptions['loosely-type-checked-files']}`));
+    log(saveLooselyTypeCheckedFilesError.message);
+    return;
+  }
+
+  const saveIgnoredErrorCodesError = saveJSONFile(
+    cliOptions['ignored-error-codes'],
+    ignoredErrorCodes,
+  );
+  if (saveIgnoredErrorCodesError) {
+    log(red(`Error when saving ${cliOptions['ignored-error-codes']}`));
+    log(saveIgnoredErrorCodesError.message);
+    return;
+  }
+
+  log('Configuration files saved successfully');
+}

--- a/src/cli/config/read-config.ts
+++ b/src/cli/config/read-config.ts
@@ -1,0 +1,39 @@
+import { yellow } from 'chalk';
+
+import { CliDependencies } from '../cli-dependencies';
+
+export const readConfig = ({
+  readJSONArray,
+  log,
+  cliOptions,
+}: Pick<CliDependencies, 'readJSONArray' | 'log' | 'cliOptions'>) => {
+  const ignoredErrorCodesArray: string[] | Error = readJSONArray(
+    cliOptions['ignored-error-codes'],
+    cliOptions.init,
+  );
+  const looselyTypeCheckedFilePathsArray: string[] | Error = readJSONArray(
+    cliOptions['loosely-type-checked-files'],
+    cliOptions.init,
+  );
+
+  if (
+    !Array.isArray(ignoredErrorCodesArray) ||
+    !Array.isArray(looselyTypeCheckedFilePathsArray)
+  ) {
+    if (ignoredErrorCodesArray instanceof Error) {
+      log(ignoredErrorCodesArray.message);
+    }
+    if (looselyTypeCheckedFilePathsArray instanceof Error) {
+      log(looselyTypeCheckedFilePathsArray.message);
+    }
+
+    log(yellow('Either fix the files or pass the --init option'));
+
+    return;
+  }
+
+  return {
+    ignoredErrorCodesArray,
+    looselyTypeCheckedFilePathsArray,
+  };
+};

--- a/src/cli/config/update-loosely-type-checked-file-paths.ts
+++ b/src/cli/config/update-loosely-type-checked-file-paths.ts
@@ -1,0 +1,35 @@
+import { areSetsEqual } from '../../utils';
+import { CliDependencies } from '../cli-dependencies';
+
+export function updateLooselyTypeCheckedFilePaths(
+  {
+    cliOptions,
+    log,
+    saveJSONFile,
+  }: Pick<CliDependencies, 'cliOptions' | 'log' | 'saveJSONFile'>,
+  looselyTypeCheckedFilePaths: Set<string>,
+  updatedLooselyTypeCheckedFilePaths: Set<string>,
+) {
+  if (
+    areSetsEqual(
+      looselyTypeCheckedFilePaths,
+      updatedLooselyTypeCheckedFilePaths,
+    )
+  ) {
+    return;
+  }
+
+  log('Updating the list of loosely type-checked files...');
+
+  try {
+    saveJSONFile(
+      cliOptions['loosely-type-checked-files'],
+      Array.from(updatedLooselyTypeCheckedFilePaths).sort(),
+    );
+
+    log('The list of loosely type-checked files updated successfully');
+  } catch (error) {
+    log('Error when saving the list of loosely type-checked files');
+    log(error.message);
+  }
+}

--- a/src/cli/get-default-cli-options.ts
+++ b/src/cli/get-default-cli-options.ts
@@ -1,0 +1,8 @@
+import { CliOptions } from './cli-options';
+
+export const getDefaultCliOptions = (): CliOptions => ({
+  'auto-update': false,
+  'ignored-error-codes': 'ignored-error-codes.json',
+  'loosely-type-checked-files': 'loosely-type-checked-files.json',
+  init: false,
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,3 @@
+export * from './cli-options';
+export * from './config';
+export * from './cli-dependencies';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,5 @@
 export * from './cli-options';
-export * from './config';
 export * from './cli-dependencies';
-export * from './reporting';
 export * from './cli-options-config';
-export { getProgramInput, getProgramInputAndFail } from './io';
+export * from './program';
+export { getProgramInput } from './io';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,3 +3,4 @@ export * from './config';
 export * from './cli-dependencies';
 export * from './reporting';
 export * from './cli-options-config';
+export { getProgramInput, getProgramInputAndFail } from './io';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,3 +1,5 @@
 export * from './cli-options';
 export * from './config';
 export * from './cli-dependencies';
+export * from './reporting';
+export * from './cli-options-config';

--- a/src/cli/io/get-program-input.ts
+++ b/src/cli/io/get-program-input.ts
@@ -1,0 +1,19 @@
+import { createInterface } from 'readline';
+
+export const getProgramInput = () =>
+  new Promise<string[]>((resolve) => {
+    const programInput: string[] = [];
+    const rl = createInterface(process.stdin);
+
+    rl.on('line', (line) => {
+      programInput.push(line);
+    });
+
+    rl.once('close', () => {
+      resolve(programInput);
+    });
+  });
+
+export function getProgramInputAndFail() {
+  getProgramInput().then(() => process.exit(1));
+}

--- a/src/cli/io/get-program-input.ts
+++ b/src/cli/io/get-program-input.ts
@@ -13,7 +13,3 @@ export const getProgramInput = () =>
       resolve(programInput);
     });
   });
-
-export function getProgramInputAndFail() {
-  getProgramInput().then(() => process.exit(1));
-}

--- a/src/cli/io/index.ts
+++ b/src/cli/io/index.ts
@@ -1,0 +1,1 @@
+export * from './save-json-file';

--- a/src/cli/io/index.ts
+++ b/src/cli/io/index.ts
@@ -1,1 +1,3 @@
 export * from './save-json-file';
+export * from './read-json-array';
+export * from './get-program-input';

--- a/src/cli/io/read-json-array.ts
+++ b/src/cli/io/read-json-array.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'fs';
-import { createInterface } from 'readline';
 
 export const readJSONArray = (
   path: string,
@@ -30,17 +29,3 @@ export const readJSONArray = (
 
   return parsedFile;
 };
-
-export const getProgramInput = () =>
-  new Promise<string[]>((resolve) => {
-    const programInput: string[] = [];
-    const rl = createInterface(process.stdin);
-
-    rl.on('line', (line) => {
-      programInput.push(line);
-    });
-
-    rl.once('close', () => {
-      resolve(programInput);
-    });
-  });

--- a/src/cli/io/save-json-file.ts
+++ b/src/cli/io/save-json-file.ts
@@ -1,0 +1,16 @@
+import { writeFileSync } from 'fs';
+
+export const saveJSONFile = (
+  path: string,
+  value: unknown,
+): Error | undefined => {
+  try {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    return new Error('Unknown error while saving JSON');
+  }
+};

--- a/src/cli/program.test.ts
+++ b/src/cli/program.test.ts
@@ -1,0 +1,150 @@
+import { getDefaultCliOptions } from './get-default-cli-options';
+import { program } from './program';
+
+describe('program', () => {
+  const cliDependencies: Parameters<typeof program>[0] = {
+    cliOptions: getDefaultCliOptions(),
+    log: jest.fn(),
+    readJSONArray: jest.fn(),
+    saveJSONFile: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (cliDependencies.readJSONArray as jest.Mock).mockImplementation(() => []);
+  });
+
+  describe('when initializing config files', () => {
+    const initCliDependencies: typeof cliDependencies = {
+      ...cliDependencies,
+      cliOptions: {
+        ...cliDependencies.cliOptions,
+        init: true,
+      },
+    };
+
+    it('should not initialize when no errors', () => {
+      const result = program(initCliDependencies, ['', '']);
+
+      expect(result).toBeUndefined();
+
+      expect(initCliDependencies.saveJSONFile).toHaveBeenCalledTimes(0);
+    });
+
+    it('should initialize when there are errors errors', () => {
+      const filePath = 'app/pages/site/site-pipelines/new.ts';
+      const tsErrorCode = 'TS2532';
+      const result = program(initCliDependencies, [
+        `${filePath}(1,45): error ${tsErrorCode}: Object is possibly 'undefined'.`,
+      ]);
+
+      expect(result).toBeUndefined();
+
+      expect(initCliDependencies.saveJSONFile).toHaveBeenCalledTimes(2);
+      expect(
+        initCliDependencies.saveJSONFile,
+      ).toHaveBeenCalledWith(
+        initCliDependencies.cliOptions['loosely-type-checked-files'],
+        [filePath],
+      );
+      expect(
+        initCliDependencies.saveJSONFile,
+      ).toHaveBeenCalledWith(
+        initCliDependencies.cliOptions['ignored-error-codes'],
+        [tsErrorCode],
+      );
+    });
+
+    it('should handle different paths in options', () => {
+      const temporaryCliDependencies: typeof initCliDependencies = {
+        ...initCliDependencies,
+        cliOptions: {
+          ...initCliDependencies.cliOptions,
+          'ignored-error-codes': 'ignored.json',
+          'loosely-type-checked-files': 'files.json',
+        },
+      };
+
+      const filePath = 'app/pages/site/site-pipelines/new.ts';
+      const tsErrorCode = 'TS2532';
+      const result = program(temporaryCliDependencies, [
+        `${filePath}(1,45): error ${tsErrorCode}: Object is possibly 'undefined'.`,
+      ]);
+
+      expect(result).toBeUndefined();
+
+      expect(initCliDependencies.saveJSONFile).toHaveBeenCalledTimes(2);
+      expect(
+        initCliDependencies.saveJSONFile,
+      ).toHaveBeenCalledWith('files.json', [filePath]);
+      expect(
+        initCliDependencies.saveJSONFile,
+      ).toHaveBeenCalledWith('ignored.json', [tsErrorCode]);
+    });
+  });
+
+  describe('when reading existing config', () => {
+    it('should reading/parsing log errors', () => {
+      (cliDependencies.readJSONArray as jest.Mock)
+        .mockImplementationOnce(() => new Error('Cannot parse array'))
+        .mockImplementationOnce(() => new Error('Cannot parse another array'));
+
+      const result = program(cliDependencies, ['']);
+
+      expect(result?.error).toBe(true);
+      expect(cliDependencies.log).toHaveBeenCalledWith('Cannot parse array');
+      expect(cliDependencies.log).toHaveBeenCalledWith(
+        'Cannot parse another array',
+      );
+    });
+
+    it('should read config from files from options', () => {
+      const temporaryCliDependencies: typeof cliDependencies = {
+        ...cliDependencies,
+        cliOptions: {
+          ...cliDependencies.cliOptions,
+          'ignored-error-codes': 'ignored.json',
+          'loosely-type-checked-files': 'files.json',
+        },
+      };
+      (cliDependencies.readJSONArray as jest.Mock).mockImplementation(() => []);
+
+      const result = program(temporaryCliDependencies, ['']);
+
+      expect(result).toBeUndefined();
+      expect(cliDependencies.readJSONArray).toHaveBeenCalledWith(
+        'ignored.json',
+        false,
+      );
+      expect(cliDependencies.readJSONArray).toHaveBeenCalledWith(
+        'files.json',
+        false,
+      );
+    });
+  });
+
+  it('should fail if there are invalid TSC error codes in the config', () => {
+    (cliDependencies.readJSONArray as jest.Mock).mockImplementation(
+      (path: string) =>
+        path === cliDependencies.cliOptions['ignored-error-codes']
+          ? ['invalid code', 'another invalid code']
+          : [],
+    );
+
+    const result = program(cliDependencies, ['']);
+
+    expect(result?.error).toBe(true);
+    expect(cliDependencies.log).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid TSC error codes'),
+    );
+  });
+
+  it('should succeed if there are no TSC errors in the input', () => {
+    const result = program(cliDependencies, ['']);
+
+    expect(result).toBeUndefined();
+    expect(cliDependencies.log).toHaveBeenCalledWith(
+      expect.stringContaining('No TSC errors detected'),
+    );
+  });
+});

--- a/src/cli/program.test.ts
+++ b/src/cli/program.test.ts
@@ -1,7 +1,6 @@
+import * as chalk from 'chalk';
 import { getDefaultCliOptions } from './get-default-cli-options';
 import { program } from './program';
-
-const chalkReset = '\x1B[39m';
 
 describe('program', () => {
   const cliDependencies: Parameters<typeof program>[0] = {
@@ -14,6 +13,11 @@ describe('program', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     (cliDependencies.readJSONArray as jest.Mock).mockImplementation(() => []);
+  });
+
+  beforeAll(() => {
+    // @ts-ignore
+    chalk.level = 0;
   });
 
   describe('when initializing config files', () => {
@@ -174,7 +178,7 @@ describe('program', () => {
 
       expect(result?.error).toBe(true);
       expect(cliDependencies.log).toHaveBeenCalledWith(
-        expect.stringContaining(`4${chalkReset} errors detected`),
+        expect.stringContaining('4 errors detected'),
       );
     });
 
@@ -190,7 +194,7 @@ describe('program', () => {
 
       expect(result?.error).toBe(true);
       expect(cliDependencies.log).toHaveBeenCalledWith(
-        expect.stringContaining(`1${chalkReset} errors have been ignored`),
+        expect.stringContaining('1 errors have been ignored'),
       );
     });
 
@@ -206,7 +210,7 @@ describe('program', () => {
 
       expect(result?.error).toBe(true);
       expect(cliDependencies.log).toHaveBeenCalledWith(
-        expect.stringContaining(`3${chalkReset} errors were not ignored`),
+        expect.stringContaining('3 errors were not ignored'),
       );
     });
 
@@ -222,7 +226,7 @@ describe('program', () => {
 
       expect(result?.error).toBe(true);
       expect(cliDependencies.log).toHaveBeenCalledWith(
-        expect.stringContaining(`1${chalkReset} errors could be ignored`),
+        expect.stringContaining('1 errors could be ignored'),
       );
     });
 
@@ -239,7 +243,7 @@ describe('program', () => {
       expect(result?.error).toBe(true);
       expect(cliDependencies.log).toHaveBeenCalledWith(
         expect.stringContaining(
-          `1${chalkReset} loosely type-checked files no longer have any errors and could be strictly type-checked`,
+          '1 loosely type-checked files no longer have any errors and could be strictly type-checked',
         ),
       );
     });
@@ -257,7 +261,7 @@ describe('program', () => {
       expect(result?.error).toBe(true);
       expect(cliDependencies.log).toHaveBeenCalledWith(
         expect.stringContaining(
-          `2${chalkReset} errors could not be ignored as those codes are not in the ignored list`,
+          '2 errors could not be ignored as those codes are not in the ignored list',
         ),
       );
     });

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,0 +1,115 @@
+import * as chalk from 'chalk';
+
+import {
+  parseTscErrors,
+  partitionTscErrors,
+  validateTscErrorCodes,
+} from '../tsc-errors';
+import { CliDependencies } from './cli-dependencies';
+import {
+  initializeConfigurationFiles,
+  readConfig,
+  updateLooselyTypeCheckedFilePaths,
+} from './config';
+import {
+  aggregateReportingResults,
+  reportLooselyTypeCheckedFilePathsWithoutErrors,
+  reportTscErrorsThatCouldBeIgnored,
+  reportValidTscErrors,
+} from './reporting';
+
+export const program = (
+  cliDependencies: CliDependencies,
+  programInput: string[],
+): { error: true } | undefined => {
+  const readResult = readConfig(cliDependencies);
+  if (!readResult) {
+    return { error: true };
+  }
+
+  const {
+    ignoredErrorCodesArray,
+    looselyTypeCheckedFilePathsArray,
+  } = readResult;
+
+  const ignoredErrorCodes = new Set<string>(ignoredErrorCodesArray);
+
+  const validationErrors = validateTscErrorCodes(ignoredErrorCodes);
+  if (validationErrors.length > 0) {
+    cliDependencies.log(
+      `Invalid TSC error codes in ${cliDependencies.cliOptions['ignored-error-codes']}`,
+    );
+    validationErrors.forEach(cliDependencies.log);
+
+    return { error: true };
+  }
+
+  const looselyTypeCheckedFilePaths = new Set<string>(
+    looselyTypeCheckedFilePathsArray,
+  );
+
+  const tscErrors = parseTscErrors(programInput);
+
+  if (tscErrors.length === 0) {
+    cliDependencies.log(chalk.green('No TSC errors detected'));
+    return;
+  }
+
+  cliDependencies.log(`${chalk.red(tscErrors.length)} errors detected`);
+
+  if (cliDependencies.cliOptions.init) {
+    initializeConfigurationFiles(cliDependencies, tscErrors);
+    return;
+  }
+
+  const {
+    ignoredTscErrors,
+    unignoredTscErrors,
+    tscErrorsThatCouldBeIgnored,
+    validTscErrors,
+  } = partitionTscErrors({
+    tscErrors,
+    ignoredErrorCodes,
+    looselyTypeCheckedFilePaths,
+  });
+
+  cliDependencies.log(
+    `${chalk.yellow(ignoredTscErrors.length)} errors have been ignored`,
+  );
+
+  if (unignoredTscErrors.length > 0) {
+    cliDependencies.log(
+      `${chalk.red(unignoredTscErrors.length)} errors were not ignored`,
+    );
+  }
+
+  const updatedLooselyTypeCheckedFilePaths = new Set(
+    looselyTypeCheckedFilePaths,
+  );
+
+  const reportingResult = aggregateReportingResults([
+    reportTscErrorsThatCouldBeIgnored(
+      cliDependencies,
+      tscErrorsThatCouldBeIgnored,
+      updatedLooselyTypeCheckedFilePaths,
+    ),
+    reportLooselyTypeCheckedFilePathsWithoutErrors(
+      cliDependencies,
+      updatedLooselyTypeCheckedFilePaths,
+      tscErrors,
+    ),
+    reportValidTscErrors(cliDependencies, validTscErrors),
+  ]);
+
+  if (cliDependencies.cliOptions['auto-update']) {
+    updateLooselyTypeCheckedFilePaths(
+      cliDependencies,
+      looselyTypeCheckedFilePaths,
+      updatedLooselyTypeCheckedFilePaths,
+    );
+  }
+
+  if (reportingResult?.shouldFail) {
+    return { error: true };
+  }
+};

--- a/src/cli/reporting/aggregate-reporting-results.test.ts
+++ b/src/cli/reporting/aggregate-reporting-results.test.ts
@@ -1,0 +1,26 @@
+import { aggregateReportingResults } from './aggregate-reporting-results';
+
+describe('aggregateReportingResults', () => {
+  it('should return failure when there is at least 1 failure', () => {
+    const result = aggregateReportingResults([
+      undefined,
+      undefined,
+      { shouldFail: true },
+      undefined,
+    ]);
+
+    expect(result?.shouldFail).toBe(true);
+  });
+
+  it('should return undefined when there are no failures', () => {
+    const result = aggregateReportingResults([undefined, undefined, undefined]);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when there are no results', () => {
+    const result = aggregateReportingResults([]);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/cli/reporting/aggregate-reporting-results.ts
+++ b/src/cli/reporting/aggregate-reporting-results.ts
@@ -1,0 +1,8 @@
+import { ReportResult } from './report-result';
+
+export const aggregateReportingResults = (
+  reportResults: ReportResult[],
+): ReportResult =>
+  reportResults.some((result) => result !== undefined)
+    ? { shouldFail: true }
+    : undefined;

--- a/src/cli/reporting/index.ts
+++ b/src/cli/reporting/index.ts
@@ -1,0 +1,5 @@
+export * from './report-tsc-errors-that-could-be-ignored';
+export * from './report-loosely-type-checked-file-paths-without-errors';
+export * from './report-valid-tsc-errors';
+export * from './report-result';
+export * from './aggregate-reporting-results';

--- a/src/cli/reporting/report-loosely-type-checked-file-paths-without-errors.test.ts
+++ b/src/cli/reporting/report-loosely-type-checked-file-paths-without-errors.test.ts
@@ -1,0 +1,74 @@
+import { getDefaultCliOptions } from '../get-default-cli-options';
+import { reportLooselyTypeCheckedFilePathsWithoutErrors } from './report-loosely-type-checked-file-paths-without-errors';
+
+describe('reportLooselyTypeCheckedFilePathsWithoutErrors', () => {
+  const dependencies: Parameters<
+    typeof reportLooselyTypeCheckedFilePathsWithoutErrors
+  >[0] = {
+    cliOptions: getDefaultCliOptions(),
+    log: jest.fn(),
+  };
+
+  it('should not fail when there are no errors', () => {
+    const result = reportLooselyTypeCheckedFilePathsWithoutErrors(
+      dependencies,
+      new Set(),
+      [],
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should not fail when all loosely type-checked files have errors', () => {
+    const result = reportLooselyTypeCheckedFilePathsWithoutErrors(
+      dependencies,
+      new Set(['a']),
+      [
+        {
+          filePath: 'a',
+          rawErrorLines: [],
+          tscErrorCode: 'TS1234',
+        },
+        {
+          filePath: 'b',
+          rawErrorLines: [],
+          tscErrorCode: 'TS1235',
+        },
+      ],
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should remove loosely type-checked paths when they have no errors', () => {
+    const looselyTypeCheckedPaths = new Set(['a', 'b', 'c', 'd']);
+
+    const temporaryDependencies: typeof dependencies = {
+      ...dependencies,
+      cliOptions: {
+        ...dependencies.cliOptions,
+        'auto-update': true,
+      },
+    };
+
+    const result = reportLooselyTypeCheckedFilePathsWithoutErrors(
+      temporaryDependencies,
+      looselyTypeCheckedPaths,
+      [
+        {
+          filePath: 'a',
+          rawErrorLines: [],
+          tscErrorCode: 'TS1234',
+        },
+        {
+          filePath: 'b',
+          rawErrorLines: [],
+          tscErrorCode: 'TS1235',
+        },
+      ],
+    );
+
+    expect(result).toBeUndefined();
+    expect(Array.from(looselyTypeCheckedPaths)).toEqual(['a', 'b']);
+  });
+});

--- a/src/cli/reporting/report-loosely-type-checked-file-paths-without-errors.ts
+++ b/src/cli/reporting/report-loosely-type-checked-file-paths-without-errors.ts
@@ -1,0 +1,52 @@
+import { yellow, green } from 'chalk';
+
+import { TscError } from '../../tsc-errors';
+import { CliDependencies } from '../cli-dependencies';
+import { ReportResult } from './report-result';
+
+export function reportLooselyTypeCheckedFilePathsWithoutErrors(
+  { log, cliOptions }: Pick<CliDependencies, 'log' | 'cliOptions'>,
+  looselyTypeCheckedFilePaths: Set<string>,
+  tscErrors: TscError[],
+): ReportResult {
+  if (tscErrors.length === 0) {
+    return;
+  }
+
+  const filePathsWithErrors = new Set(
+    tscErrors.map((tscError) => tscError.filePath),
+  );
+
+  const looselyTypeCheckedFilePathsWithoutErrors = Array.from(
+    looselyTypeCheckedFilePaths,
+  ).filter((filePath) => !filePathsWithErrors.has(filePath));
+
+  if (looselyTypeCheckedFilePathsWithoutErrors.length === 0) {
+    return;
+  }
+
+  log(
+    `${yellow(
+      looselyTypeCheckedFilePathsWithoutErrors.length,
+    )} loosely type-checked files no longer have any errors and could be strictly type-checked.`,
+  );
+
+  log(looselyTypeCheckedFilePathsWithoutErrors);
+
+  if (!cliOptions['auto-update']) {
+    log(
+      `Use the ${green(
+        '--auto-update',
+      )} option to update the registry automatically.`,
+    );
+
+    return {
+      shouldFail: true,
+    };
+  }
+
+  looselyTypeCheckedFilePathsWithoutErrors.forEach((filePath) => {
+    looselyTypeCheckedFilePaths.delete(filePath);
+  });
+  log('Registry will be updated');
+}

--- a/src/cli/reporting/report-result.ts
+++ b/src/cli/reporting/report-result.ts
@@ -1,0 +1,1 @@
+export type ReportResult = { shouldFail: true } | undefined;

--- a/src/cli/reporting/report-tsc-errors-that-could-be-ignored.test.ts
+++ b/src/cli/reporting/report-tsc-errors-that-could-be-ignored.test.ts
@@ -1,0 +1,67 @@
+import { getDefaultCliOptions } from '../get-default-cli-options';
+import { reportTscErrorsThatCouldBeIgnored } from './report-tsc-errors-that-could-be-ignored';
+
+describe('reportTscErrorsThatCouldBeIgnored', () => {
+  const dependencies: Parameters<
+    typeof reportTscErrorsThatCouldBeIgnored
+  >[0] = {
+    cliOptions: getDefaultCliOptions(),
+    log: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should not fail when there are no errors', () => {
+    const result = reportTscErrorsThatCouldBeIgnored(
+      dependencies,
+      [],
+      new Set(),
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should fail when there are errors and auto-update is disabled', () => {
+    const result = reportTscErrorsThatCouldBeIgnored(
+      dependencies,
+      [
+        {
+          filePath: 'a',
+          rawErrorLines: [],
+          tscErrorCode: 'TS1234',
+        },
+      ],
+      new Set(),
+    );
+
+    expect(result?.shouldFail).toBe(true);
+  });
+
+  it('should update the loosely type-checked files when auto-update is on', () => {
+    const temporaryDependencies: typeof dependencies = {
+      ...dependencies,
+      cliOptions: {
+        ...dependencies.cliOptions,
+        'auto-update': true,
+      },
+    };
+
+    const looselyTypeCheckedFiles = new Set<string>();
+    const result = reportTscErrorsThatCouldBeIgnored(
+      temporaryDependencies,
+      [
+        {
+          filePath: 'a',
+          rawErrorLines: [],
+          tscErrorCode: 'TS1234',
+        },
+      ],
+      looselyTypeCheckedFiles,
+    );
+
+    expect(result).toBeUndefined();
+    expect(looselyTypeCheckedFiles.has('a')).toBe(true);
+  });
+});

--- a/src/cli/reporting/report-tsc-errors-that-could-be-ignored.ts
+++ b/src/cli/reporting/report-tsc-errors-that-could-be-ignored.ts
@@ -1,0 +1,46 @@
+import { green, yellow } from 'chalk';
+import { TscError } from '../../tsc-errors';
+import { CliDependencies } from '../cli-dependencies';
+import { ReportResult } from './report-result';
+
+export function reportTscErrorsThatCouldBeIgnored(
+  { log, cliOptions }: Pick<CliDependencies, 'log' | 'cliOptions'>,
+  tscErrorsThatCouldBeIgnored: TscError[],
+  looselyTypeCheckedFilePaths: Set<string>,
+): ReportResult {
+  if (tscErrorsThatCouldBeIgnored.length === 0) {
+    return;
+  }
+
+  log(
+    `${yellow(
+      tscErrorsThatCouldBeIgnored.length,
+    )} errors could be ignored, as their error codes are ignored`,
+  );
+
+  if (!cliOptions['auto-update']) {
+    log(
+      `Use the ${green(
+        '--auto-update',
+      )} option to update the registry automatically.`,
+    );
+
+    return {
+      shouldFail: true,
+    };
+  }
+
+  const initialLooselyTypeCheckedFilesCount =
+    tscErrorsThatCouldBeIgnored.length;
+  tscErrorsThatCouldBeIgnored.forEach((tscError) => {
+    looselyTypeCheckedFilePaths.add(tscError.filePath);
+  });
+  const additionalLooselyTypeCheckedFilePaths =
+    tscErrorsThatCouldBeIgnored.length - initialLooselyTypeCheckedFilesCount;
+
+  log(
+    `Additional ${yellow(
+      additionalLooselyTypeCheckedFilePaths,
+    )} files will be ignored - registry will be updated`,
+  );
+}

--- a/src/cli/reporting/report-valid-tsc-errors.test.ts
+++ b/src/cli/reporting/report-valid-tsc-errors.test.ts
@@ -1,0 +1,43 @@
+import { reportValidTscErrors } from './report-valid-tsc-errors';
+
+describe('reportValidTscErrors', () => {
+  const dependencies: Parameters<typeof reportValidTscErrors>[0] = {
+    log: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should not fail when there are no errors', () => {
+    const result = reportValidTscErrors(dependencies, []);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should fail when there are errors', () => {
+    const result = reportValidTscErrors(dependencies, [
+      { filePath: 'a', tscErrorCode: 'TS1234', rawErrorLines: [] },
+    ]);
+
+    expect(result?.shouldFail).toBe(true);
+  });
+
+  it('should log raw error lines', () => {
+    reportValidTscErrors(dependencies, [
+      {
+        filePath: 'a',
+        tscErrorCode: 'TS1234',
+        rawErrorLines: ['error a', 'details'],
+      },
+      {
+        filePath: 'b',
+        tscErrorCode: 'TS1234',
+        rawErrorLines: ['error b', 'details'],
+      },
+    ]);
+
+    expect(dependencies.log).toHaveBeenCalledWith('error a\ndetails');
+    expect(dependencies.log).toHaveBeenCalledWith('error b\ndetails');
+  });
+});

--- a/src/cli/reporting/report-valid-tsc-errors.ts
+++ b/src/cli/reporting/report-valid-tsc-errors.ts
@@ -1,0 +1,24 @@
+import { red } from 'chalk';
+
+import { TscError } from '../../tsc-errors';
+import { CliDependencies } from '../cli-dependencies';
+import { ReportResult } from './report-result';
+
+export function reportValidTscErrors(
+  { log }: Pick<CliDependencies, 'log'>,
+  validTscErrors: TscError[],
+): ReportResult {
+  if (validTscErrors.length === 0) {
+    return;
+  }
+
+  log(
+    `${red(
+      validTscErrors.length,
+    )} errors could not be ignored as those codes are not in the ignored list`,
+  );
+
+  validTscErrors.forEach((error) => log(error.rawErrorLines.join('\n')));
+
+  return { shouldFail: true };
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { createInterface } from 'readline';
 
 export const readJSONArray = (
@@ -29,12 +29,6 @@ export const readJSONArray = (
   }
 
   return parsedFile;
-};
-
-export const saveJSONArray = (path: string, arr: string[]) => {
-  const sortedArr = [...arr].sort();
-
-  writeFileSync(path, `${JSON.stringify(sortedArr, null, 2)}\n`);
 };
 
 export const getProgramInput = () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,13 @@ import {
   validateTscErrorCodes,
 } from './tsc-errors';
 import { saveJSONArray, readJSONArray, getProgramInput } from './helpers';
+import {
+  CliOptions,
+  getCliDependencies,
+  initializeConfigurationFiles,
+} from './cli';
 
-const options = yargs(process.argv)
+const options: CliOptions = yargs(process.argv)
   .options({
     'ignored-error-codes': {
       type: 'string',
@@ -97,7 +102,8 @@ const options = yargs(process.argv)
       );
 
       if (options.init) {
-        initializeConfigurationFiles(filePathsWithErrors, tscErrors);
+        const cliDependencies = getCliDependencies(options);
+        initializeConfigurationFiles(cliDependencies, tscErrors);
         process.exit(0);
       }
 
@@ -242,22 +248,4 @@ function reportTscErrorsThatCouldBeIgnored(
   }
 
   return updateFileRegistryPossible;
-}
-
-function initializeConfigurationFiles(
-  filePathsWithErrors: Set<string>,
-  tscErrors: TscError[],
-) {
-  console.log('Initializing configuration files...');
-
-  saveJSONArray(
-    options['loosely-type-checked-files'],
-    Array.from(filePathsWithErrors),
-  );
-  saveJSONArray(
-    options['ignored-error-codes'],
-    Array.from(new Set(tscErrors.map((tscError) => tscError.tscErrorCode))),
-  );
-
-  console.log('Configuration files saved successfully');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,11 @@
 import yargs from 'yargs';
-import * as chalk from 'chalk';
 
 import {
-  parseTscErrors,
-  partitionTscErrors,
-  validateTscErrorCodes,
-} from './tsc-errors';
-import {
-  aggregateReportingResults,
   CliOptions,
   cliOptionsConfig,
   getCliDependencies,
   getProgramInput,
-  getProgramInputAndFail,
-  initializeConfigurationFiles,
-  readConfig,
-  reportLooselyTypeCheckedFilePathsWithoutErrors,
-  reportTscErrorsThatCouldBeIgnored,
-  reportValidTscErrors,
-  updateLooselyTypeCheckedFilePaths,
+  program,
 } from './cli';
 
 const options: CliOptions = yargs(process.argv)
@@ -26,100 +13,14 @@ const options: CliOptions = yargs(process.argv)
   .parse();
 const cliDependencies = getCliDependencies(options);
 
-(() => {
-  const readResult = readConfig(cliDependencies);
-  if (!readResult) {
-    getProgramInputAndFail();
-    return;
-  }
-
-  const {
-    ignoredErrorCodesArray,
-    looselyTypeCheckedFilePathsArray,
-  } = readResult;
-
-  const ignoredErrorCodes = new Set<string>(ignoredErrorCodesArray);
-
-  const validationErrors = validateTscErrorCodes(ignoredErrorCodes);
-  if (validationErrors.length > 0) {
-    console.log(`Invalid TSC error codes in ${options['ignored-error-codes']}`);
-    validationErrors.forEach(console.log);
-    getProgramInputAndFail();
-    return;
-  }
-
-  const looselyTypeCheckedFilePaths = new Set<string>(
-    looselyTypeCheckedFilePathsArray,
-  );
-
-  getProgramInput()
-    .then((programInput) => {
-      const tscErrors = parseTscErrors(programInput);
-
-      if (tscErrors.length === 0) {
-        console.log(chalk.green('No TSC errors detected'));
-        return;
-      }
-
-      console.log(`${chalk.red(tscErrors.length)} errors detected`);
-
-      if (options.init) {
-        initializeConfigurationFiles(cliDependencies, tscErrors);
-        process.exit(0);
-      }
-
-      const {
-        ignoredTscErrors,
-        unignoredTscErrors,
-        tscErrorsThatCouldBeIgnored,
-        validTscErrors,
-      } = partitionTscErrors({
-        tscErrors,
-        ignoredErrorCodes,
-        looselyTypeCheckedFilePaths,
-      });
-
-      console.log(
-        `${chalk.yellow(ignoredTscErrors.length)} errors have been ignored`,
-      );
-
-      if (unignoredTscErrors.length > 0) {
-        console.log(
-          `${chalk.red(unignoredTscErrors.length)} errors were not ignored`,
-        );
-      }
-
-      const updatedLooselyTypeCheckedFilePaths = new Set(
-        looselyTypeCheckedFilePaths,
-      );
-
-      const reportingResult = aggregateReportingResults([
-        reportTscErrorsThatCouldBeIgnored(
-          cliDependencies,
-          tscErrorsThatCouldBeIgnored,
-          updatedLooselyTypeCheckedFilePaths,
-        ),
-        reportLooselyTypeCheckedFilePathsWithoutErrors(
-          cliDependencies,
-          updatedLooselyTypeCheckedFilePaths,
-          tscErrors,
-        ),
-        reportValidTscErrors(cliDependencies, validTscErrors),
-      ]);
-
-      if (reportingResult?.shouldFail) {
-        process.exitCode = 1;
-      }
-
-      if (options['auto-update']) {
-        updateLooselyTypeCheckedFilePaths(
-          cliDependencies,
-          looselyTypeCheckedFilePaths,
-          updatedLooselyTypeCheckedFilePaths,
-        );
-      }
-    })
-    .catch((error) => {
-      console.error('Unknown error', error);
-    });
-})();
+getProgramInput()
+  .then((programInput) => program(cliDependencies, programInput))
+  .then((result) => {
+    if (result?.error) {
+      process.exit(1);
+    }
+  })
+  .catch((error) => {
+    console.error('Unknown error', error);
+    process.exit(1);
+  });

--- a/src/utils/are-sets-equal.test.ts
+++ b/src/utils/are-sets-equal.test.ts
@@ -1,0 +1,30 @@
+import { areSetsEqual } from './are-sets-equal';
+
+describe('areSetsEqual', () => {
+  it('should return true if it is the same reference', () => {
+    const set = new Set();
+
+    expect(areSetsEqual(set, set)).toBe(true);
+  });
+
+  it('should return false if sets contain different number of elements', () => {
+    const set1 = new Set();
+    const set2 = new Set(['a']);
+
+    expect(areSetsEqual(set1, set2)).toBe(false);
+  });
+
+  it('should return false if sets contain different elements', () => {
+    const set1 = new Set(['b']);
+    const set2 = new Set(['a']);
+
+    expect(areSetsEqual(set1, set2)).toBe(false);
+  });
+
+  it('should return true if sets contain the same elements', () => {
+    const set1 = new Set(['a', 'b']);
+    const set2 = new Set(['a', 'b']);
+
+    expect(areSetsEqual(set1, set2)).toBe(true);
+  });
+});

--- a/src/utils/are-sets-equal.ts
+++ b/src/utils/are-sets-equal.ts
@@ -1,0 +1,11 @@
+export const areSetsEqual = (set1: Set<any>, set2: Set<any>) => {
+  if (set1 === set2) {
+    return true;
+  }
+
+  if (set1.size !== set2.size) {
+    return false;
+  }
+
+  return Array.from(set1).every((elem) => set2.has(elem));
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './partition';
+export * from './are-sets-equal';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,5 +4,5 @@
     "outDir": "./dist",
     "noEmit": false
   },
-  "exclude": ["**/*.test.ts"]
+  "files": ["./src/index.ts"]
 }


### PR DESCRIPTION
This MR extracts some functions from `index.ts` to separate files and adds tests to them