### PR TITLE
refactor(auto-update)!: skip files that could be ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+**BREAKING CHANGES**
+
+- `--auto-update` will no longer add new file paths to the registry
+
+  When there were errors that could be ignored because the error code is already
+  ignored in other files, `--auto-update` used to add these new file paths to
+  the registry. This allowed regressions to sneak in, since a file that was
+  already conforming to the stricter config could re-appear in the registry of
+  ignored files.
+
+  In situations like this one, these file paths will be no longer added to the
+  registry, and the program will fail when there are errors in files that could
+  be ignored.
+
+  If you need to start ignoring these errors, use the `--init` flag to
+  regenerate the registries.
+
+  See <https://github.com/Gelio/loose-ts-check/issues/16> for more information.
+
 ## v1.3.0 (2023-01-08)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ incrementally, where only some existing files are allowed to have TS errors.
 - ignores specific TS errors from specific files
 - detects files that no longer have to be loosely type-checked
 - auto-updates the loosely type-checked list of files when a file no longer has
-  error
+  errors
 - auto-updates the ignored error codes when there are no errors of that type
 - loosely type-checked files can be specified using globs
 

--- a/src/cli/program.test.ts
+++ b/src/cli/program.test.ts
@@ -325,23 +325,6 @@ describe('program', () => {
         },
       };
 
-      it('should add new loosely type-checked files whose errors can be ignored', () => {
-        looselyTypeCheckedFiles = ['a', 'b'];
-        ignoredErrorCodes = ['TS1111', 'TS2222'];
-        const result = program(temporaryCliDependencies, [
-          createErrorLine('a', 'TS1111'),
-          createErrorLine('b', 'TS1111'),
-          createErrorLine('c', 'TS2222'),
-        ]);
-
-        expect(result).toBeUndefined();
-
-        expect(temporaryCliDependencies.saveJSONFile).toHaveBeenCalledWith(
-          temporaryCliDependencies.cliOptions['loosely-type-checked-files'],
-          ['a', 'b', 'c'],
-        );
-      });
-
       it('should remove loosely type-checked file paths that have no errors', () => {
         looselyTypeCheckedFiles = ['a', 'b'];
         ignoredErrorCodes = ['TS1111'];

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -95,7 +95,6 @@ export const program = (
     reportTscErrorsThatCouldBeIgnored(
       cliDependencies,
       tscErrorsThatCouldBeIgnored,
-      updatedLooselyTypeCheckedFilePaths,
     ),
     reportLooselyTypeCheckedFilePathsWithoutErrors(
       cliDependencies,

--- a/src/cli/reporting/report-tsc-errors-that-could-be-ignored.test.ts
+++ b/src/cli/reporting/report-tsc-errors-that-could-be-ignored.test.ts
@@ -1,10 +1,8 @@
-import { getDefaultCliOptions } from '../get-default-cli-options';
 import { reportTscErrorsThatCouldBeIgnored } from './report-tsc-errors-that-could-be-ignored';
 
 describe('reportTscErrorsThatCouldBeIgnored', () => {
   const dependencies: Parameters<typeof reportTscErrorsThatCouldBeIgnored>[0] =
     {
-      cliOptions: getDefaultCliOptions(),
       log: jest.fn(),
     };
 
@@ -13,54 +11,20 @@ describe('reportTscErrorsThatCouldBeIgnored', () => {
   });
 
   it('should not fail when there are no errors', () => {
-    const result = reportTscErrorsThatCouldBeIgnored(
-      dependencies,
-      [],
-      new Set(),
-    );
+    const result = reportTscErrorsThatCouldBeIgnored(dependencies, []);
 
     expect(result).toBeUndefined();
   });
 
-  it('should fail when there are errors and auto-update is disabled', () => {
-    const result = reportTscErrorsThatCouldBeIgnored(
-      dependencies,
-      [
-        {
-          filePath: 'a',
-          rawErrorLines: [],
-          tscErrorCode: 'TS1234',
-        },
-      ],
-      new Set(),
-    );
+  it('should fail when there are errors', () => {
+    const result = reportTscErrorsThatCouldBeIgnored(dependencies, [
+      {
+        filePath: 'a',
+        rawErrorLines: [],
+        tscErrorCode: 'TS1234',
+      },
+    ]);
 
     expect(result?.shouldFail).toBe(true);
-  });
-
-  it('should update the loosely type-checked files when auto-update is on', () => {
-    const temporaryDependencies: typeof dependencies = {
-      ...dependencies,
-      cliOptions: {
-        ...dependencies.cliOptions,
-        'auto-update': true,
-      },
-    };
-
-    const looselyTypeCheckedFiles = new Set<string>();
-    const result = reportTscErrorsThatCouldBeIgnored(
-      temporaryDependencies,
-      [
-        {
-          filePath: 'a',
-          rawErrorLines: [],
-          tscErrorCode: 'TS1234',
-        },
-      ],
-      looselyTypeCheckedFiles,
-    );
-
-    expect(result).toBeUndefined();
-    expect(looselyTypeCheckedFiles.has('a')).toBe(true);
   });
 });

--- a/src/cli/reporting/report-tsc-errors-that-could-be-ignored.ts
+++ b/src/cli/reporting/report-tsc-errors-that-could-be-ignored.ts
@@ -4,9 +4,8 @@ import { CliDependencies } from '../cli-dependencies';
 import { ReportResult } from './report-result';
 
 export function reportTscErrorsThatCouldBeIgnored(
-  { log, cliOptions }: Pick<CliDependencies, 'log' | 'cliOptions'>,
+  { log }: Pick<CliDependencies, 'log'>,
   tscErrorsThatCouldBeIgnored: TscError[],
-  looselyTypeCheckedFilePaths: Set<string>,
 ): ReportResult {
   if (tscErrorsThatCouldBeIgnored.length === 0) {
     return;
@@ -22,29 +21,13 @@ export function reportTscErrorsThatCouldBeIgnored(
     log(tscError.rawErrorLines.join('\n')),
   );
 
-  if (!cliOptions['auto-update']) {
-    log(
-      `Use the ${green(
-        '--auto-update',
-      )} option to update the registry automatically.`,
-    );
-
-    return {
-      shouldFail: true,
-    };
-  }
-
-  const initialLooselyTypeCheckedFilesCount =
-    tscErrorsThatCouldBeIgnored.length;
-  tscErrorsThatCouldBeIgnored.forEach((tscError) => {
-    looselyTypeCheckedFilePaths.add(tscError.filePath);
-  });
-  const additionalLooselyTypeCheckedFilePaths =
-    tscErrorsThatCouldBeIgnored.length - initialLooselyTypeCheckedFilesCount;
-
   log(
-    `Additional ${yellow(
-      additionalLooselyTypeCheckedFilePaths,
-    )} files will be ignored - registry will be updated`,
+    `Use the ${green(
+      '--init',
+    )} option to add these file paths to the registry.`,
   );
+
+  return {
+    shouldFail: true,
+  };
 }


### PR DESCRIPTION
The `auto-update` flag will no longer cause new paths to be added to the registry of ignored files. This prevents regressions from sneaking in, when some file was already conforming to the stricter config and an ignored error code started appearing in that file.

Fixes https://github.com/Gelio/loose-ts-check/issues/16