### PR TITLE
chore: include TypeScript 5.0 in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
   See <https://github.com/Gelio/loose-ts-check/issues/16> for more information.
 
+Engineering:
+
+- Include TypeScript 5.0 in integration tests.
+
 ## v1.3.0 (2023-01-08)
 
 Features:

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -48,7 +48,7 @@ const looseTsCheckCommand = `FORCE_COLOR=0 ${looseTsCheckBinaryPath}`;
 
 const tsVersions = process.env.ONLY_LATEST_VERSION
   ? ['latest']
-  : ['3.9', '4.0', '4.4', '4.9', 'latest'];
+  : ['3.9', '4.0', '4.4', '4.9', '5.0', 'latest'];
 
 async function prepareTestDirectory({
   tsVersion,


### PR DESCRIPTION
With TypeScript 5.0 released, we should start testing it explicitly too. `latest` currently points to 5.0.3, so it is close enough, but I want to future-proof so future contributors test both TS 5.0 and latest