### PR TITLE
fix: parse newer tsc format and strip ansi colors

### DIFF
--- a/src/tsc-errors/parse-tsc-errors.ts
+++ b/src/tsc-errors/parse-tsc-errors.ts
@@ -1,10 +1,11 @@
 import { TscError } from './types';
 
-const tscErrorLineRegExp = /^(.*)\(\d+,\d+\): error (TS\d{4,}):.*$/;
+const tscErrorLineRegExp = /^(.*)(?:\(\d+,\d+\):|:\d+:\d+ -) error (TS\d{4,}):.*$/;
+const stripAnsiRegExp = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
 
 export const parseTscErrors = (tscOutput: string[]) => {
   const tscErrors: TscError[] = [];
-  const tscOutputLines = tscOutput.filter((line) => line.trim() !== '');
+  const tscOutputLines = tscOutput.map((line) => line.replace(stripAnsiRegExp, '').trim()).filter((line) => line);
   let lastTscError: TscError | undefined;
 
   tscOutputLines.forEach((line) => {


### PR DESCRIPTION
This is a basic workaround to address two issues:

1. `tsc` output includes colors which makes lines non-matching `tscErrorLineRegExp` -> sanitize input
2. `tsc` output has different format than expected (I'd assume newer version of `tsc`, I'm currently using `5.2.2`) -> extend `tscErrorLineRegExp` with match for an alternative format

My `tsc` error output looks as follows:
```
./some/path/filename.ts:12:3 - error TS4567: Compilation error message.
```